### PR TITLE
actions: use tags for release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,9 @@
 name: Release on PyPI
 
 on:
-  release:
-    types: [created]
+  push:
+    tags:
+    - v*
 
 jobs:
   deploy:


### PR DESCRIPTION
This seems to be more consistent across the projects.