### PR TITLE
tests: ensure old pluggy is tested in at least one config

### DIFF
--- a/legacy.constraints
+++ b/legacy.constraints
@@ -1,0 +1,10 @@
+# This constraints file is used to ensure old package versions
+# are covered by at least one test configuration.
+
+# This is the pluggy version we expect to use in py2.6 environments.
+pluggy==0.5.2
+
+# Need to set ancient versions for these packages to get versions which
+# will work with the above.
+pytest<3.7
+pytest-cov<2

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,9 @@ whitelist_externals=sh
 [testenv:py27]
 # .txt file pins requirements to py3 versions,
 # does not work for py2
-deps=-rtest-requirements.in
+deps=
+	-rtest-requirements.in
+	-clegacy.constraints
 
 [testenv:static]
 deps=


### PR DESCRIPTION
Looks like pluggy 0.5.2 is the version we expect to use in the ancient
py2.6 environments, so make sure at least one CI config tests against
it. (This is a lightweight alternative to having the CI actually cover
python 2.6.)