### PR TITLE
Bump version to 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - n/a
 
+## [1.0.0] - 2021-07-19
+
+- Set version to 1.0.0 to indicate that SemVer is now in effect.
+
 ## [0.3.0] - 2021-06-30
 
 - Introduced hooks/event system in `pubtools.pluggy`. See documentation for more info.
@@ -17,5 +21,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release from release-engineering organization
 
-[Unreleased]: https://github.com/release-engineering/pubtools/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/release-engineering/pubtools/compare/v1.0.0...HEAD
+[1.0.0]: https://github.com/release-engineering/pubtools/compare/v0.3.0...v1.0.0
 [0.3.0]: https://github.com/release-engineering/pubtools/compare/v0.2.0...v0.3.0

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ def get_requirements():
 
 setup(
     name="pubtools",
-    version="0.3.0",
+    version="1.0.0",
     packages=find_packages(exclude=["tests"]),
     url="https://github.com/release-engineering/pubtools",
     license="GNU General Public License",


### PR DESCRIPTION
The intent is to now put this into production, so it's time to set the
version to 1.0.0 and commit to a stable API.