### PR TITLE
chore: updates from repo-playbooks


### DIFF
--- a/.github/workflows/pip-compile.yml
+++ b/.github/workflows/pip-compile.yml
@@ -16,7 +16,7 @@ jobs:
          python-version: 3.8
 
      - name: Install system dependencies
-       run: sudo apt-get install -y tox 
+       run: sudo apt-get install -y tox libkrb5-dev
 
      - name: pip-compile
        uses: technote-space/create-pr-action@v2

--- a/tox.ini
+++ b/tox.ini
@@ -39,7 +39,9 @@ testpaths = tests
 # Recompile all requirements .txt files using pip-compile.
 # Don't edit me - I'm deployed from a template.
 deps = pip-tools
-basepython = python3.8
+basepython = python3.9
+skip_install = true
+skipsdist = true
 commands =
     pip-compile -U --generate-hashes requirements-dev.in
     pip-compile -U --generate-hashes requirements-docs.in


### PR DESCRIPTION
## Automated update

This is an automated update generated by ansible playbooks.
See [the playbook repo](https://url.corp.redhat.com/300a997) for more information.

## Summary of updates
### update pip-compile workflow

This GitHub Actions workflow will regularly invoke pip-compile over
relevant files in this repo and submit pull requests when python dependencies need
updating.

#### Recent changes

- [3c68aac](https://gitlab.cee.redhat.com/rmcgover/repo-playbooks/-/commit/3c68aac34e876d5d2737af0bdc47a73758e56c87) `repo_facts: add support for probing native deps`
- [33c0f02](https://gitlab.cee.redhat.com/rmcgover/repo-playbooks/-/commit/33c0f026074aa1fa2fe08f8018656d9d338fafe2) `Refactor pip-compile to use tox`
- [8503811](https://gitlab.cee.redhat.com/rmcgover/repo-playbooks/-/commit/850381164be5a66ef48f54aed4d343aabb149a85) `Refactor repo_updates for improved messages`


### update tox config for pip-compile

Adds a tox environment for running pip-compile. This can be used either
locally or within CI to update all dependencies to the latest versions.

#### Recent changes

- [0c689de](https://gitlab.cee.redhat.com/rmcgover/repo-playbooks/-/commit/0c689de772fb710d75c952ebcba9abe06d48b179) `pip-compile: drop unnecessary sdist/install steps`
- [668b7f3](https://gitlab.cee.redhat.com/rmcgover/repo-playbooks/-/commit/668b7f342c3311fab46a690d2caf3c2d8d336b8f) `pip-compile: migrate to python3.9 as default`
- [33c0f02](https://gitlab.cee.redhat.com/rmcgover/repo-playbooks/-/commit/33c0f026074aa1fa2fe08f8018656d9d338fafe2) `Refactor pip-compile to use tox`

