### PR TITLE
actions: fix pip-compile action vs tox.ini version mismatch

### DIFF
--- a/.github/workflows/pip-compile.yml
+++ b/.github/workflows/pip-compile.yml
@@ -12,8 +12,7 @@ jobs:
      - name: Setup Python
        uses: actions/setup-python@v2
        with:
-         # TODO: multi-version support
-         python-version: 3.8
+         python-version: "3.9"
 
      - name: Install system dependencies
        run: sudo apt-get install -y tox libkrb5-dev


### PR DESCRIPTION
Both tox.ini and this github workflow need to request the same
python version. There was previously a mismatch.