### PR TITLE
chore: updates from repo-playbooks


### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+charset = utf-8
+
+[*.py]
+indent_style = space
+indent_size = 4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,15 +9,19 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
+
     - uses: actions/checkout@v2
+
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
         python-version: '3.x'
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         pip install setuptools wheel twine
+
     - name: Build and publish
       env:
         TWINE_USERNAME: __token__

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,2 @@
+[settings]
+profile=black

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,3 +9,14 @@ repos:
     rev: 5.6.4
     hooks:
     - id: isort
+
+-   repo: https://github.com/frnmst/md-toc
+    rev: 8.0.0
+    hooks:
+    - id: md-toc
+
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.0.1
+    hooks:
+    - id: end-of-file-fixer
+    - id: trailing-whitespace


### PR DESCRIPTION
## Automated update

This is an automated update generated by ansible playbooks.
See [the playbook repo](https://url.corp.redhat.com/300a997) for more information.

## Summary of updates
### update editorconfig

The [editorconfig](https://editorconfig.org/) file ensures consistent
handling of whitespace and other editor configuration.

#### Recent changes

- [a16f7ad](https://gitlab.cee.redhat.com/rmcgover/repo-playbooks/-/commit/a16f7adcd1ae615e60a00fd560c1a8a77abf4561) `Introduce editorconfig role`


### update pre-commit config

The pre-commit tool enforces consistency on all incoming changes.

#### Recent changes

- [2d0f586](https://gitlab.cee.redhat.com/rmcgover/repo-playbooks/-/commit/2d0f58695872ba04d09aacb3a57f6b4aaf28f213) `Introduce md-toc to pre-commit`
- [47da301](https://gitlab.cee.redhat.com/rmcgover/repo-playbooks/-/commit/47da3019fc34f35d4e17217f6efb72003bbb02b2) `pre-commit: enable some additional generic hooks`
- [686ea1b](https://gitlab.cee.redhat.com/rmcgover/repo-playbooks/-/commit/686ea1ba38c6fb1ee57b7907a1a96243dc23c724) `Add a TODO list of other pre-commit hooks to investigate`


### update pypi release workflow

This GitHub Actions workflow will release to PyPI whenever a "v{major.minor.patch}"
tag is created in the repository.

#### Recent changes

- [f031a91](https://gitlab.cee.redhat.com/rmcgover/repo-playbooks/-/commit/f031a91b9ffd08c23ee573b6c3946e53a662d30d) `Add role for pypi release action`

