### PR TITLE
actions: revert to 'pip install' for tox

### DIFF
--- a/.github/workflows/pip-compile.yml
+++ b/.github/workflows/pip-compile.yml
@@ -15,7 +15,10 @@ jobs:
          python-version: "3.9"
 
      - name: Install system dependencies
-       run: sudo apt-get install -y tox libkrb5-dev
+       run: sudo apt-get install -y libkrb5-dev
+
+     - name: Install tox
+       run: pip install tox
 
      - name: pip-compile
        uses: technote-space/create-pr-action@v2


### PR DESCRIPTION
I thought it'd make sense to use the debian/ubuntu package for tox,
but in reality it causes issues due to debian 'unvendoring' patches.
Revert to 'pip install tox', as it was done previously.

https://github.com/pre-commit/pre-commit/issues/1383#issuecomment-611091348
is a relevant comment.