### PR TITLE
actions: use consistent dep installation everywhere

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,7 +16,9 @@ jobs:
         with:
           python-version: 3.8
       - name: Install system dependencies
-        run: sudo apt-get install -y tox libkrb5-dev
+        run: sudo apt-get install -y libkrb5-dev
+      - name: Install Tox
+        run: pip install tox
       - name: Run Tox
         run: tox -e docs
       - name: Publish

--- a/.github/workflows/tox-tests.yml
+++ b/.github/workflows/tox-tests.yml
@@ -11,6 +11,8 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: 2.7
+      - name: Install system dependencies
+        run: sudo apt-get install -y libkrb5-dev
       - name: Install Tox
         run: pip install tox
       - name: Run Tox
@@ -23,6 +25,8 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: 3.8
+      - name: Install system dependencies
+        run: sudo apt-get install -y libkrb5-dev
       - name: Install Tox
         run: pip install tox
       - name: Run Tox
@@ -36,7 +40,9 @@ jobs:
         with:
           python-version: 3.8
       - name: Install system dependencies
-        run: sudo apt-get install -y tox libkrb5-dev
+        run: sudo apt-get install -y libkrb5-dev
+      - name: Install Tox
+        run: pip install tox
       - name: Run Tox
         run: tox -e docs
   coverage:
@@ -47,6 +53,8 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: 3.8
+      - name: Install system dependencies
+        run: sudo apt-get install -y libkrb5-dev
       - name: Install Tox
         run: pip install tox
       - name: Run Tox


### PR DESCRIPTION
Make all the workflows use a consistent setup for native dependencies
and tox.

- Always use 'pip install' for tox, as per
  36fc61697d8e8bd52ec3ad2bf8ef2a76eb692baf

- For the sake of simplicity, always install the native deps rather than
  trying to do that only for certain tox envs. Will help keep the CI
  stable as dependencies change. Would fix the CI failure in
  https://github.com/release-engineering/pubtools/pull/16.