### PR TITLE
hooks: add eager loading of entry points to ensure initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- n/a
+- Introduced `pubtools.hooks` entry point group to support hook-only libraries.
 
 ## [1.0.0] - 2021-07-19
 

--- a/docs/hooks.rst
+++ b/docs/hooks.rst
@@ -140,6 +140,25 @@ names and signatures should match exactly the names of the corresponding hookspe
     # Register this module as a plugin.
     pm.register(sys.modules['__name__'])
 
+Your module must be imported for your hookimpls to take effect.
+
+If you're unsure whether your module will be imported, you may declare entry
+points in the ``pubtools.hooks`` group; pubtools will enforce that all modules
+in this group are imported when ``task_context`` is invoked.
+
+For example, in setup.py, one may declare:
+
+.. code-block:: python
+
+    entry_points={
+      "pubtools.hooks": [
+          # Left-hand side can be anything.
+          # Right-hand side is the name of your module containing a
+          # call to "pm.register".
+          "hooks = pubtools.foo._impl.hooks",
+      ]
+    },
+
 Be aware that:
 
 - Your hookimpl could be invoked by any thread. Blocking the current thread

--- a/docs/mkhooks
+++ b/docs/mkhooks
@@ -6,9 +6,8 @@
 import os
 import textwrap
 import inspect
-import pkg_resources
 
-from pubtools.pluggy import pm
+from pubtools.pluggy import pm, task_context
 
 BUILD_DIR = os.path.join(os.path.dirname(__file__), "_build")
 HOOKS_OUTPUT = os.path.join(BUILD_DIR, "hooks")
@@ -135,11 +134,6 @@ class SpecWrapper:
 
 
 def all_hookspecs():
-    # Eagerly load all entry points, forcing everything installed to be imported.
-    # This ensures any import-time hookspecs are registered.
-    for ep in pkg_resources.iter_entry_points("console_scripts"):
-        ep.resolve()
-
     hooknames = [name for name in dir(pm.hook) if not name.startswith("_")]
     hookspecs = []
 
@@ -153,13 +147,15 @@ def all_hookspecs():
 
 
 def main():
-    hookspecs = all_hookspecs()
+    # We run in task context since it ensures all hooks are loaded.
+    with task_context():
+        hookspecs = all_hookspecs()
 
-    os.makedirs(BUILD_DIR, exist_ok=True)
+        os.makedirs(BUILD_DIR, exist_ok=True)
 
-    with open(HOOKS_OUTPUT, "wt") as out:
-        for spec in hookspecs:
-            out.write(spec.doc)
+        with open(HOOKS_OUTPUT, "wt") as out:
+            for spec in hookspecs:
+                out.write(spec.doc)
 
 
 if __name__ == "__main__":

--- a/pubtools/_impl/pluggy.py
+++ b/pubtools/_impl/pluggy.py
@@ -1,13 +1,40 @@
 from __future__ import absolute_import
 
 import sys
+import logging
 from contextlib import contextmanager
 
+import pkg_resources
 import pluggy
+
+LOG = logging.getLogger("pubtools")
 
 pm = pluggy.PluginManager("pubtools")
 hookspec = pluggy.HookspecMarker("pubtools")
 hookimpl = pluggy.HookimplMarker("pubtools")
+
+
+def resolve_hooks():
+    # A private helper to ensure all code defining hookspecs/hookimpls has been imported
+    # before continuing.
+
+    # 1. Eagerly load any pubtools console_scripts entry points.
+    #
+    # This will pick up hookspecs from task libraries such as pubtools-quay.
+    #
+    for ep in pkg_resources.iter_entry_points("console_scripts"):
+        if ep.module_name.startswith("pubtools"):
+            ep.resolve()
+            LOG.debug("Resolved %s", ep)
+
+    # 2. Eagerly load any pubtools.hooks entry points.
+    #
+    # This is a group we provide so that any hook-only modules, which might otherwise
+    # not be imported by anyone, can request themselves to be imported.
+    #
+    for ep in pkg_resources.iter_entry_points("pubtools.hooks"):
+        ep.resolve()
+        LOG.debug("Resolved %s", ep)
 
 
 @hookspec
@@ -45,9 +72,12 @@ def task_context():
 
     The context manager will ensure that:
 
+    * hookspecs/hookimpls are resolved across all installed libraries.
     * :func:`task_start` is invoked when the block is entered.
     * :func:`task_stop` is invoked when the block is exited.
     """
+    resolve_hooks()
+
     pm.hook.task_start()
 
     failed = True

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 pluggy
+setuptools

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ def get_requirements():
 
 setup(
     name="pubtools",
-    version="1.0.0",
+    version="1.1.0",
     packages=find_packages(exclude=["tests"]),
     url="https://github.com/release-engineering/pubtools",
     license="GNU General Public License",

--- a/tests/hooks/test_entry_points.py
+++ b/tests/hooks/test_entry_points.py
@@ -1,0 +1,52 @@
+import sys
+
+from pkg_resources import get_distribution, EntryPoint
+
+from pubtools.pluggy import task_context
+
+
+def test_task_context_loads_entry_points(monkeypatch):
+    """task_context eagerly resolves console_scripts and pubtools.hooks entry points."""
+
+    # Need some valid distribution to use here; don't care which one.
+    # Just pick something we know is installed.
+    dist = get_distribution("pytest")
+
+    entry_map = dist.get_entry_map()
+
+    # This group already exists in pytest.
+    scripts = entry_map["console_scripts"]
+
+    # This is a new group we'll force onto the map.
+    hooks = {}
+    monkeypatch.setitem(entry_map, "pubtools.hooks", hooks)
+
+    # Set up some console scripts entry points. We'll make them point at existing
+    # modules so that an import will succeed.
+    #
+    # This one is pubtools.* , so it should be imported
+    monkeypatch.setitem(
+        scripts, "some-script", EntryPoint("some-script", "pubtools.pluggy")
+    )
+
+    # This should be ignored
+    monkeypatch.setitem(
+        scripts, "other-script", EntryPoint("other-script", "something.non.existent")
+    )
+
+    # Set up a hook entry point.
+    monkeypatch.setitem(hooks, "anything", EntryPoint("anything", "pytest"))
+
+    # Effectively "un-import" these modules so we can observe that task_context
+    # has the side-effect of importing them.
+    assert "pubtools.pluggy" in sys.modules
+    assert "pytest" in sys.modules
+    del sys.modules["pubtools.pluggy"]
+    del sys.modules["pytest"]
+
+    with task_context():
+        # As soon as we've entered the task context, the modules referenced from
+        # those entry points should be imported, ensuring we can now use hooks with
+        # everything registered
+        assert "pubtools.pluggy" in sys.modules
+        assert "pytest" in sys.modules


### PR DESCRIPTION
The recommended approach to registering hookimpls and hookspecs is to
register them when your module is imported.

Problem: there can be modules which want to declare hooks but
wouldn't be imported during the natural course of events while running a
task. Hence, hooks could be missing.

The mkhooks script in this repo already ran into this problem and it
attempted to solve it by eagerly importing all console_scripts. That
works for projects like pubtools-quay, but is insufficient in general
because there may be "hook-only" libraries which have no
console_scripts.

For example, consider a hypothetical pubtools-umb library with desired
behavior: if it's installed, and certain env vars are set, it will
attach to various hooks and send messages on a message bus when those
are activated.

Such a project has no need of any console_script, and we also don't want
to require each project to "import pubtools.umb" just to activate it.
So, there is no obvious way to arrange for the relevant module to be
imported.

This commit provides a solution: a hook-only library such as
pubtools-umb can declare an entry point in pubtools.hooks, and
task_context will ensure any such entry points are fully resolved before
proceeding.