### PR TITLE
ci: bump py3 version to 3.9

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: 3.9
       - name: Install system dependencies
         run: sudo apt-get install -y libkrb5-dev
       - name: Install Tox

--- a/.github/workflows/tox-tests.yml
+++ b/.github/workflows/tox-tests.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: 3.9
       - name: Install system dependencies
         run: sudo apt-get install -y libkrb5-dev
       - name: Install Tox
@@ -38,7 +38,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: 3.9
       - name: Install system dependencies
         run: sudo apt-get install -y libkrb5-dev
       - name: Install Tox
@@ -52,7 +52,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: 3.9
       - name: Install system dependencies
         run: sudo apt-get install -y libkrb5-dev
       - name: Install Tox

--- a/docs/devguide.rst
+++ b/docs/devguide.rst
@@ -36,7 +36,7 @@ Target platforms
 Projects should aim to be compatible with the following environments:
 
 - Python 2.6 (yes, really)
-- Python 3.8 and later
+- Python 3.9 and later
 - Red Hat flavored operating systems (RHEL, CentOS, Fedora)
 
 The requirement to support Python 2 is likely to be dropped during 2022.


### PR DESCRIPTION
Use python 3.9 as the new minimum version for py3.

The motivation for changing it now is to resolve the issue seen in
pip-compile PR #38. The problem is that pip-compile is already using
python 3.9 but other CI configs used 3.8. This is not valid, as the set
of resolved dependencies can differ between the two versions.

It could be solved by either downgrading the python used for pip-compile
or upgrading the python used elsewhere. In this commit I pick the latter
approach, seeing as python 3.9 is readily available on all the py3
target platforms.