### PR TITLE
gh-actions: fix py27 test environment

### DIFF
--- a/.github/workflows/tox-tests.yml
+++ b/.github/workflows/tox-tests.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   py27:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - name: Setup Python


### PR DESCRIPTION
Github are rolling out ubuntu-22.04 as the latest ubuntu runner. setup-python cannot install python 2.7 on that OS, so force this test environment to stick with ubuntu-20.04.