### PR TITLE
Drop black from github actions CI

### DIFF
--- a/.github/workflows/tox-tests.yml
+++ b/.github/workflows/tox-tests.yml
@@ -3,20 +3,6 @@ name: Tox tests
 on: [push, pull_request]
 
 jobs:
-  static:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Setup Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.9
-      - name: Install system dependencies
-        run: sudo apt-get install -y libkrb5-dev
-      - name: Install Tox
-        run: pip install tox
-      - name: Run Tox
-        run: tox -e static
   docs:
     runs-on: ubuntu-latest
     steps:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,11 @@
 repos:
 
 -   repo: https://github.com/ambv/black
-    rev: 21.6b0
+    rev: 23.1.0
     hooks:
     - id: black
 
 -   repo: https://github.com/pycqa/isort/
-    rev: 5.6.4
+    rev: 5.12.0
     hooks:
     - id: isort

--- a/docs/mkhooks
+++ b/docs/mkhooks
@@ -3,9 +3,9 @@
 # A helper invoked during doc build to generate an index of all hooks
 # into hooks.rst.
 #
+import inspect
 import os
 import textwrap
-import inspect
 
 from pubtools.pluggy import pm, task_context
 
@@ -46,7 +46,6 @@ def dedent(docstr):
     # the rest.
 
     try:
-
         if not docstr.startswith("\n") and not docstr.startswith(" "):
             idx = docstr.index("\n ") + 1
 

--- a/pubtools/_impl/mallopt.py
+++ b/pubtools/_impl/mallopt.py
@@ -27,10 +27,10 @@ possible for the env vars to be used as documented.
 
 import logging
 import sys
-from os import environ
 from ctypes import cdll
+from os import environ
 
-from pubtools.pluggy import pm, hookimpl
+from pubtools.pluggy import hookimpl, pm
 
 LOG = logging.getLogger("pubtools")
 
@@ -64,7 +64,7 @@ def set_mallopt_tunables():
     # Set malloc options via mallopt() for all defined tunables.
     # Raises an exception on any type of error.
     libc = cdll.LoadLibrary("libc.so.6")
-    for (varname, flag) in TUNABLES.items():
+    for varname, flag in TUNABLES.items():
         if varname in environ:
             value = int(environ[varname])
             if libc.mallopt(flag, value) != 1:

--- a/pubtools/_impl/pluggy.py
+++ b/pubtools/_impl/pluggy.py
@@ -1,5 +1,5 @@
-import sys
 import logging
+import sys
 from contextlib import contextmanager
 
 import pkg_resources

--- a/pubtools/pluggy.py
+++ b/pubtools/pluggy.py
@@ -1,8 +1,3 @@
-from pubtools._impl.pluggy import (
-    pm,
-    hookimpl,
-    hookspec,
-    task_context,
-)
+from pubtools._impl.pluggy import hookimpl, hookspec, pm, task_context
 
 __all__ = ["pm", "hookimpl", "hookspec", "task_context"]

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -1,2 +1,1 @@
-black
 pre-commit

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
 
 
 def get_description():

--- a/tests/hooks/test_entry_points.py
+++ b/tests/hooks/test_entry_points.py
@@ -1,6 +1,6 @@
 import sys
 
-from pkg_resources import get_distribution, EntryPoint
+from pkg_resources import EntryPoint, get_distribution
 
 from pubtools.pluggy import task_context
 

--- a/tests/hooks/test_mallopt_hook.py
+++ b/tests/hooks/test_mallopt_hook.py
@@ -1,5 +1,5 @@
-import os
 import ctypes
+import os
 
 import pytest
 

--- a/tests/hooks/test_task_context.py
+++ b/tests/hooks/test_task_context.py
@@ -1,8 +1,8 @@
 import sys
+
 import pytest
 
-
-from pubtools.pluggy import pm, hookimpl, task_context
+from pubtools.pluggy import hookimpl, pm, task_context
 
 
 class EventSpy(object):

--- a/tox.ini
+++ b/tox.ini
@@ -6,12 +6,6 @@ deps=-rtest-requirements.txt
 commands=pytest -v {posargs}
 whitelist_externals=sh
 
-[testenv:static]
-deps=
-	-rrequirements-dev.txt
-commands=
-	black --check .
-
 [testenv:cov]
 usedevelop=true
 commands=


### PR DESCRIPTION
"tox -e static" previously ran the black autoformatter using a version managed by pip-compile.

Problem: pre-commit also runs black, but this uses the version defined in the pre-commit config. If there are any differences in the black code style between the two versions of the tool, they will not both be able to pass.

This recently blocked dependency updates for this repo because a new release of black is available which has some incompatibilities with the version used by pre-commit.

Rather than trying to keep both versions in sync, it makes more sense to apply the tool in just one place; so let's drop it from tox & github actions and rely only on pre-commit.ci to both run the tool and manage the version of the tool.

This PR includes a one-time manual update of the pre-commit hooks (and code updates to make them pass) because the currently referenced older versions aren't able to pass pre-commit.ci.