### PR TITLE
Pin bandit version

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -38,12 +38,12 @@ commands =
 
 [testenv:py3-bandit-exitzero]
 deps=
-    -rrequirements-bandit.txt
+    bandit<=1.7.5
 commands=
     bandit -r . -l --exclude './.tox' --exit-zero
 
 [testenv:py3-bandit]
 deps=
-    -rrequirements-bandit.txt
+    bandit<=1.7.5
 commands=
     bandit -r . -ll --exclude './.tox'


### PR DESCRIPTION
We pin the version of Bandit SAST tool to make the CI tests more predictable. If we used the latest version available without pinning it, the CI tests could start failing on new Bandit version without any changes in our codebase.

We pin the Bandit version by adding version requirement to tox.ini.