### PR TITLE
[ci] fix install of OS packages in CI workflows

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,8 +15,10 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: 3.9
-      - name: Install system dependencies
-        run: sudo apt-get install -y libkrb5-dev
+      - name: Install OS packages
+        run: |
+          sudo apt-get -y update
+          sudo apt-get install -y libkrb5-dev
       - name: Install Tox
         run: pip install tox
       - name: Run Tox

--- a/.github/workflows/pip-compile.yml
+++ b/.github/workflows/pip-compile.yml
@@ -14,8 +14,10 @@ jobs:
        with:
          python-version: "3.9"
 
-     - name: Install system dependencies
-       run: sudo apt-get install -y libkrb5-dev
+     - name: Install OS packages
+       run: |
+         sudo apt-get -y update
+         sudo apt-get install -y libkrb5-dev
 
      - name: Install tox
        run: pip install tox

--- a/.github/workflows/tox-tests.yml
+++ b/.github/workflows/tox-tests.yml
@@ -11,8 +11,10 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: 3.9
-      - name: Install system dependencies
-        run: sudo apt-get install -y libkrb5-dev
+      - name: Install OS packages
+        run: |
+          sudo apt-get -y update
+          sudo apt-get install -y libkrb5-dev
       - name: Install Tox
         run: pip install tox
       - name: Run Tox
@@ -25,8 +27,10 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: 3.9
-      - name: Install system dependencies
-        run: sudo apt-get install -y libkrb5-dev
+      - name: Install OS packages
+        run: |
+          sudo apt-get -y update
+          sudo apt-get install -y libkrb5-dev
       - name: Install Tox
         run: pip install tox
       - name: Run Tox
@@ -40,8 +44,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Install RPM
-        run: sudo apt-get install -y rpm
+      - name: Install OS packages
+        run: |
+          sudo apt-get -y update
+          sudo apt-get install -y rpm
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
@@ -54,8 +60,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Install RPM
-        run: sudo apt-get install -y rpm
+      - name: Install OS packages
+        run: |
+          sudo apt-get -y update
+          sudo apt-get install -y rpm
       - name: Setup Python
         uses: actions/setup-python@v2
         with:


### PR DESCRIPTION
We should be using "apt-get update" to update package lists before installing any new packages. This has never mattered before, but recently the installation of various packages started to fail with 404 errors, which are resolved by updating the package lists first.