### PR TITLE
Fix issues in otel tests causing failures after upgrading deps

### DIFF
--- a/tests/tracing/test_instrument_tracing.py
+++ b/tests/tracing/test_instrument_tracing.py
@@ -13,6 +13,7 @@ def test_instrument_func_in_context(monkeypatch, fake_span_exporter):
     monkeypatch.setenv("OTEL_SERVICE_NAME", "local-test2")
 
     tw = get_trace_wrapper()
+    tw._reset()
 
     @tw.instrument_func(span_name="child_span")
     def foo():
@@ -44,6 +45,7 @@ def test_instrument_func_carrier(monkeypatch, fake_span_exporter):
     carrier = {"traceparent": f"00-{root_trace_id}-{root_span_id}-01"}
 
     tw = get_trace_wrapper()
+    tw._reset()
 
     @tw.instrument_func(span_name="func_with_carrier", carrier=carrier)
     def foo():
@@ -69,6 +71,7 @@ def test_instrument_func_multiple_threads(monkeypatch, fake_span_exporter):
     monkeypatch.setenv("traceparent", f"00-{root_trace_id}-{root_span_id}-01")
 
     tw = get_trace_wrapper()
+    tw._reset()
 
     @tw.instrument_func(span_name="sub_thread_span")
     def sub_thread():
@@ -120,6 +123,7 @@ def test_instrument_func_exception(monkeypatch, fake_span_exporter):
     monkeypatch.setenv("OTEL_TRACING", "true")
     monkeypatch.setenv("OTEL_SERVICE_NAME", "local-test3")
     tw = get_trace_wrapper()
+    tw._reset()
 
     @tw.instrument_func(span_name="func_with_exception")
     def func_with_exception():


### PR DESCRIPTION
These tests tried to ensure that a TracingWrapper existed with tracing enabled by doing:

    monkeypatch.setenv("OTEL_TRACING", "true")
    monkeypatch.setenv("OTEL_SERVICE_NAME", "local-test2")
    tw = get_trace_wrapper()

However, that's not guaranteed to work because get_trace_wrapper() might have already been called prior to the test, while OTEL_TRACING was NOT set to "true", initializing the global singleton to an object with tracing disabled.

The most straightforward way to fix this would initially seem to be: make the tests not use the singleton but instead create a fresh TracingWrapper for each one. Unfortunately that doesn't work because opentelemetry library itself has some singletons which can't be adjusted after initialization, forcing us to only use a singleton as well.

So, provide a private _reset method just for these tests which can ensure that the TracingWrapper definitely has tracing enabled, even if it was previously initialized with tracing disabled.