### PR TITLE
Update codecov-action to v4 for tokenless uploads from forked repos

### DIFF
--- a/.github/workflows/tox-tests.yml
+++ b/.github/workflows/tox-tests.yml
@@ -36,7 +36,9 @@ jobs:
       - name: Run Tox
         run: tox -e cov
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v4
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
           fail_ci_if_error: true
           verbose: true


### PR DESCRIPTION
codecov-action now requires token for upload. However, v4 supports tokeless uploads from PRs on forked repos. Hence, this adds the token env var for codecov-action and updates the version to v4.