### PR TITLE
ci: drop unnecessary usage of codecov

### DIFF
--- a/.github/workflows/tox-tests.yml
+++ b/.github/workflows/tox-tests.yml
@@ -35,13 +35,6 @@ jobs:
         run: pip install tox
       - name: Run Tox
         run: tox -e cov
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-        with:
-          fail_ci_if_error: true
-          verbose: true
   bandit-exitzero:
     runs-on: ubuntu-latest
     steps:

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ whitelist_externals=sh
 [testenv:cov]
 usedevelop=true
 commands=
-	pytest --cov-report=xml --cov=src/pubtools {posargs}
+	pytest --cov-report=term --cov=src/pubtools --cov-fail-under=100 {posargs}
 
 [testenv:docs]
 deps=


### PR DESCRIPTION
The codecov step of the CI workflow still shows some spurious failures after commit 8a68e4d27b0.

Since this project has 100% coverage anyway, codecov is not particularly useful as the coverage can be enforced using the --cov-fail-under option. Let's do that to have one less source of potential issues in the CI.